### PR TITLE
Finished initial implementation of CID fonts 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.19)
     cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 project(PDF-Generator VERSION 1.0
-                  DESCRIPTION "Component to generate Thirdfort PDFs"
+                  DESCRIPTION "Library to generate PDFs"
                   LANGUAGES CXX)
 
 include(cmake/collect_dependencies.cmake)

--- a/include/face.hpp
+++ b/include/face.hpp
@@ -36,8 +36,9 @@ class Face {
     double getLineGap();
     int getCapHeight();
     float getItalicAngle();
-    std::pair<float, std::string> shape(std::string_view text, float points, hb_script_t script = HB_SCRIPT_LATIN,
-                                        hb_direction_t direction = HB_DIRECTION_LTR, std::string_view language = "en");
+    std::pair<float, std::vector<std::pair<std::vector<uint32_t>, int32_t>>>
+    shape(std::string_view text, float points, hb_script_t script = HB_SCRIPT_LATIN,
+          hb_direction_t direction = HB_DIRECTION_LTR, std::string_view language = "en");
     float getHeight(std::string text);
     int getWeight() {
         return hb_style_get_value(face, HB_STYLE_TAG_WEIGHT);

--- a/include/face.hpp
+++ b/include/face.hpp
@@ -22,19 +22,22 @@ class Document;
 
 class Face {
     SubsetInputHolder subsetInput;
-    UnicodeSetHolder glyphSet;
+    GlyphSetHolder glyphSet;
     FaceHolder face;
     double scale;
     const std::string handle;
 
   public:
+    std::set<std::string> charSet;
     Face(FaceHolder face, double scale, std::string handle);
 
     double getAscender();
     double getDescender();
+    double getLineGap();
     int getCapHeight();
     float getItalicAngle();
-    std::pair<float, std::string> shape(std::string text, float points);
+    std::pair<float, std::string> shape(std::string_view text, float points, hb_script_t script = HB_SCRIPT_LATIN,
+                                        hb_direction_t direction = HB_DIRECTION_LTR, std::string_view language = "en");
     float getHeight(std::string text);
     int getWeight() {
         return hb_style_get_value(face, HB_STYLE_TAG_WEIGHT);
@@ -45,7 +48,7 @@ class Face {
     float getSlantAngle() {
         return hb_style_get_value(face, HB_STYLE_TAG_SLANT_ANGLE);
     }
-    UnicodeSetHolder &getUsedGlyphs() {
+    GlyphSetHolder &getUsedGlyphs() {
         return glyphSet;
     }
     hb_codepoint_t getGlyph(hb_codepoint_t unicodeCodepoint) {

--- a/include/font.hpp
+++ b/include/font.hpp
@@ -9,7 +9,6 @@
     #include <hb.h>
     #include <qpdf/Buffer.hh>
     #include <qpdf/QPDFObjectHandle.hh>
-    #include <qpdf/QUtil.hh>
 
     #include <climits>
     #include <filesystem>
@@ -56,7 +55,7 @@ class Font {
     } headTable;
 
     class OS2Table {
-        static constexpr uint32_t Tag = 1751474532;
+        static constexpr uint32_t Tag = 1330851634;
         FontTableParser parser;
 
       public:
@@ -112,652 +111,20 @@ class Font {
         OS2Table(HbFontT *font) : parser{font, Tag} {};
 
     } os2Table;
-
-    class NameTable {
-      public:
-        static constexpr uint32_t Tag = 1851878757;
-        enum class RecordType : uint16_t {
-            Family = 1,
-            SubFamily,
-            UID,
-            FullName,
-            Version,
-            PostScriptName,
-            TypographicFamily = 16,
-            TypographicSubFamily,
-            CompatibleFull,
-            VariationsPostScriptNamePrefix = 25
-        };
-        enum class LanguageID {
-            En,
-            Fr,
-            De,
-            It,
-            Nl,
-            Sv,
-            Es,
-            Da,
-            Pt,
-            No,
-            He,
-            Ja,
-            Ar,
-            Fi,
-            El,
-            Is,
-            Mt,
-            Tr,
-            Hr,
-            ZhHant,
-            Ur,
-            Hi,
-            Th,
-            Ko,
-            Lt,
-            Pl,
-            Hu,
-            Lv,
-            Se,
-            Fo,
-            Fa,
-            Ru,
-            Zh,
-            NlBE,
-            Ga,
-            Sq,
-            Ro,
-            Cz,
-            Sk,
-            Si,
-            Yi,
-            Sr,
-            Mk,
-            Bg,
-            Uk,
-            Be,
-            Uz,
-            Kk,
-            AzCyrl,
-            AzArab,
-            Hy,
-            Ka,
-            Mo,
-            Ky,
-            Tg,
-            Tk,
-            MnCN,
-            Mn,
-            Ps,
-            Ks,
-            Ku,
-            Sd,
-            Bo,
-            Ne,
-            Sa,
-            Mr,
-            Bn,
-            As,
-            Gu,
-            Pa,
-            Or,
-            Ml,
-            Kn,
-            Ta,
-            Te,
-            My,
-            Km,
-            Lo,
-            Vi,
-            Id,
-            Tl,
-            Ms,
-            MsArab,
-            Am,
-            Ti,
-            Om,
-            So,
-            Sw,
-            Rw,
-            Rn,
-            Ny,
-            Mg,
-            Eo,
-            Cy,
-            Eu,
-            Ca,
-            La,
-            Qu,
-            Gn,
-            Ay,
-            Tt,
-            Ug,
-            Dz,
-            Jv,
-            Su,
-            Gl,
-            Af,
-            Br,
-            Iu,
-            Gd,
-            Gv,
-            To,
-            ElPolyton,
-            Kl,
-            Az,
-            Nn,
-            Unknown
-        };
-
-      private:
-        enum class WinLanguageID {
-            Af = 0x0436,
-            Sq = 0x041C,
-            Gsw = 0x0484,
-            Am = 0x045E,
-            ArDZ = 0x1401,
-            ArBH = 0x3C01,
-            Ar = 0x0C01,
-            ArIQ = 0x0801,
-            ArJO = 0x2C01,
-            ArKW = 0x3401,
-            ArLB = 0x3001,
-            ArLY = 0x1001,
-            ArMA = 0x1801,
-            ArOM = 0x2001,
-            ArQA = 0x4001,
-            ArSA = 0x0401,
-            ArSY = 0x2801,
-            ArTN = 0x1C01,
-            ArAE = 0x3801,
-            ArYE = 0x2401,
-            Hy = 0x042B,
-            As = 0x044D,
-            AzCyrl = 0x082C,
-            Az = 0x042C,
-            Ba = 0x046D,
-            Eu = 0x042D,
-            Be = 0x0423,
-            Bn = 0x0845,
-            BnIN = 0x0445,
-            BsCyrl = 0x201A,
-            Bs = 0x141A,
-            Br = 0x047E,
-            Bg = 0x0402,
-            Ca = 0x0403,
-            ZhHK = 0x0C04,
-            ZhMO = 0x1404,
-            Zh = 0x0804,
-            ZhSG = 0x1004,
-            ZhTW = 0x0404,
-            Co = 0x0483,
-            Hr = 0x041A,
-            HrBA = 0x101A,
-            Cs = 0x0405,
-            Da = 0x0406,
-            Prs = 0x048C,
-            Dv = 0x0465,
-            NlBE = 0x0813,
-            Nl = 0x0413,
-            EnAU = 0x0C09,
-            EnBZ = 0x2809,
-            EnCA = 0x1009,
-            En029 = 0x2409,
-            EnIN = 0x4009,
-            EnIE = 0x1809,
-            EnJM = 0x2009,
-            EnMY = 0x4409,
-            EnNZ = 0x1409,
-            EnPH = 0x3409,
-            EnSG = 0x4809,
-            EnZA = 0x1C09,
-            EnTT = 0x2C09,
-            EnGB = 0x0809,
-            En = 0x0409,
-            EnZW = 0x3009,
-            Et = 0x0425,
-            Fo = 0x0438,
-            Fil = 0x0464,
-            Fi = 0x040B,
-            FrBE = 0x080C,
-            FrCA = 0x0C0C,
-            Fr = 0x040C,
-            FrLU = 0x140C,
-            FrMC = 0x180C,
-            FrCH = 0x100C,
-            Fy = 0x0462,
-            Gl = 0x0456,
-            Ka = 0x0437,
-            DeAT = 0x0C07,
-            De = 0x0407,
-            DeLI = 0x1407,
-            DeLU = 0x1007,
-            DeCH = 0x0807,
-            El = 0x0408,
-            Kl = 0x046F,
-            Gu = 0x0447,
-            Ha = 0x0468,
-            He = 0x040D,
-            Hi = 0x0439,
-            Hu = 0x040E,
-            Is = 0x040F,
-            Ig = 0x0470,
-            Id = 0x0421,
-            Iu = 0x045D,
-            IuLatn = 0x085D,
-            Ga = 0x083C,
-            Xh = 0x0434,
-            Zu = 0x0435,
-            It = 0x0410,
-            ItCH = 0x0810,
-            Ja = 0x0411,
-            Kn = 0x044B,
-            Kk = 0x043F,
-            Km = 0x0453,
-            Quc = 0x0486,
-            Rw = 0x0487,
-            Sw = 0x0441,
-            Kok = 0x0457,
-            Ko = 0x0412,
-            Ky = 0x0440,
-            Lo = 0x0454,
-            Lv = 0x0426,
-            Lt = 0x0427,
-            Dsb = 0x082E,
-            Lb = 0x046E,
-            Mk = 0x042F,
-            MsBN = 0x083E,
-            Ms = 0x043E,
-            Ml = 0x044C,
-            Mt = 0x043A,
-            Mi = 0x0481,
-            Arn = 0x047A,
-            Mr = 0x044E,
-            Moh = 0x047C,
-            Mn = 0x0450,
-            MnCN = 0x0850,
-            Ne = 0x0461,
-            Nb = 0x0414,
-            Nn = 0x0814,
-            Oc = 0x0482,
-            Or = 0x0448,
-            Ps = 0x0463,
-            Pl = 0x0415,
-            Pt = 0x0416,
-            PtPT = 0x0816,
-            Pa = 0x0446,
-            QuBO = 0x046B,
-            QuEC = 0x086B,
-            Qu = 0x0C6B,
-            Ro = 0x0418,
-            Rm = 0x0417,
-            Ru = 0x0419,
-            Smn = 0x243B,
-            SmjNO = 0x103B,
-            Smj = 0x143B,
-            SeFI = 0x0C3B,
-            Se = 0x043B,
-            SeSE = 0x083B,
-            Sms = 0x203B,
-            SmaNO = 0x183B,
-            Sms1 = 0x1C3B,
-            Sa = 0x044F,
-            SrCyrlBA = 0x1C1A,
-            Sr = 0x0C1A,
-            SrLatnBA = 0x181A,
-            SrLatn = 0x081A,
-            Nso = 0x046C,
-            Tn = 0x0432,
-            Si = 0x045B,
-            Sk = 0x041B,
-            Sl = 0x0424,
-            EsAR = 0x2C0A,
-            EsBO = 0x400A,
-            EsCL = 0x340A,
-            EsCO = 0x240A,
-            EsCR = 0x140A,
-            EsDO = 0x1C0A,
-            EsEC = 0x300A,
-            EsSV = 0x440A,
-            EsGT = 0x100A,
-            EsHN = 0x480A,
-            EsMX = 0x080A,
-            EsNI = 0x4C0A,
-            EsPA = 0x180A,
-            EsPY = 0x3C0A,
-            EsPE = 0x280A,
-            EsPR = 0x500A,
-            Es = 0x0C0A,
-            Es1 = 0x040A,
-            EsUS = 0x540A,
-            EsUY = 0x380A,
-            EsVE = 0x200A,
-            SvFI = 0x081D,
-            Sv = 0x041D,
-            Syr = 0x045A,
-            Tg = 0x0428,
-            Tzm = 0x085F,
-            Ta = 0x0449,
-            Tt = 0x0444,
-            Te = 0x044A,
-            Th = 0x041E,
-            Bo = 0x0451,
-            Tr = 0x041F,
-            Tk = 0x0442,
-            Ug = 0x0480,
-            Uk = 0x0422,
-            Hsb = 0x042E,
-            Ur = 0x0420,
-            UzCyrl = 0x0843,
-            Uz = 0x0443,
-            Vi = 0x042A,
-            Cy = 0x0452,
-            Wo = 0x0488,
-            Sah = 0x0485,
-            Ii = 0x0478,
-            Yo = 0x046A
-        };
-
-        enum class MacLanguageID {
-            En,
-            Fr,
-            De,
-            It,
-            Nl,
-            Sv,
-            Es,
-            Da,
-            Pt,
-            No,
-            He,
-            Ja,
-            Ar,
-            Fi,
-            El,
-            Is,
-            Mt,
-            Tr,
-            Hr,
-            ZhHant,
-            Ur,
-            Hi,
-            Th,
-            Ko,
-            Lt,
-            Pl,
-            Hu,
-            Es2,
-            Lv,
-            Se,
-            Fo,
-            Fa,
-            Ru,
-            Zh,
-            NlBE,
-            Ga,
-            Sq,
-            Ro,
-            Cz,
-            Sk,
-            Si,
-            Yi,
-            Sr,
-            Mk,
-            Bg,
-            Uk,
-            Be,
-            Uz,
-            Kk,
-            AzCyrl,
-            AzArab,
-            Hy,
-            Ka,
-            Mo,
-            Ky,
-            Tg,
-            Tk,
-            MnCN,
-            Mn,
-            Ps,
-            Ks,
-            Ku,
-            Sd,
-            Bo,
-            Ne,
-            Sa,
-            Mr,
-            Bn,
-            As,
-            Gu,
-            Pa,
-            Or,
-            Ml,
-            Kn,
-            Ta,
-            Te,
-            Si2,
-            My,
-            Km,
-            Lo,
-            Vi,
-            Id,
-            Tl,
-            Ms,
-            MsArab,
-            Am,
-            Ti,
-            Om,
-            So,
-            Sw,
-            Rw,
-            Rn,
-            Ny,
-            Mg,
-            Eo,
-            Cy = 123,
-            Eu,
-            Ca,
-            La,
-            Qu,
-            Gn,
-            Ay,
-            Tt,
-            Ug,
-            Dz,
-            Jv,
-            Su,
-            Gl,
-            Af,
-            Br,
-            Iu,
-            Gd,
-            Gv,
-            Ga2,
-            To,
-            ElPolyton,
-            Kl,
-            Az,
-            Nn
-        };
-
-        static inline std::map<WinLanguageID, LanguageID> WinMap{
-            {WinLanguageID::Af, LanguageID::Af},         {WinLanguageID::Sq, LanguageID::Sq},
-            {WinLanguageID::Gsw, LanguageID::De},        {WinLanguageID::Am, LanguageID::Am},
-            {WinLanguageID::ArDZ, LanguageID::Ar},       {WinLanguageID::ArBH, LanguageID::Ar},
-            {WinLanguageID::Ar, LanguageID::Ar},         {WinLanguageID::ArIQ, LanguageID::Ar},
-            {WinLanguageID::ArJO, LanguageID::Ar},       {WinLanguageID::ArKW, LanguageID::Ar},
-            {WinLanguageID::ArLB, LanguageID::Ar},       {WinLanguageID::ArLY, LanguageID::Ar},
-            {WinLanguageID::ArMA, LanguageID::Ar},       {WinLanguageID::ArOM, LanguageID::Ar},
-            {WinLanguageID::ArQA, LanguageID::Ar},       {WinLanguageID::ArSA, LanguageID::Ar},
-            {WinLanguageID::ArSY, LanguageID::Ar},       {WinLanguageID::ArTN, LanguageID::Ar},
-            {WinLanguageID::ArAE, LanguageID::Ar},       {WinLanguageID::ArYE, LanguageID::Ar},
-            {WinLanguageID::Hy, LanguageID::Am},         {WinLanguageID::As, LanguageID::As},
-            {WinLanguageID::AzCyrl, LanguageID::AzCyrl}, {WinLanguageID::Az, LanguageID::Az},
-            {WinLanguageID::Ba, LanguageID::Ru},         {WinLanguageID::Eu, LanguageID::Eu},
-            {WinLanguageID::Be, LanguageID::Be},         {WinLanguageID::Bn, LanguageID::Bn},
-            {WinLanguageID::BnIN, LanguageID::Bn},       {WinLanguageID::BsCyrl, LanguageID::Ru},
-            {WinLanguageID::Bs, LanguageID::En},         {WinLanguageID::Br, LanguageID::Br},
-            {WinLanguageID::Bg, LanguageID::Bg},         {WinLanguageID::Ca, LanguageID::Ca},
-            {WinLanguageID::ZhHK, LanguageID::Zh},       {WinLanguageID::ZhMO, LanguageID::Zh},
-            {WinLanguageID::Zh, LanguageID::Zh},         {WinLanguageID::ZhSG, LanguageID::Zh},
-            {WinLanguageID::ZhTW, LanguageID::Zh},       {WinLanguageID::Co, LanguageID::Fr},
-            {WinLanguageID::Hr, LanguageID::Hr},         {WinLanguageID::HrBA, LanguageID::En},
-            {WinLanguageID::Cs, LanguageID::Pl},         {WinLanguageID::Da, LanguageID::Da},
-            {WinLanguageID::Prs, LanguageID::Fa},        {WinLanguageID::Dv, LanguageID::Unknown},
-            {WinLanguageID::NlBE, LanguageID::NlBE},     {WinLanguageID::Nl, LanguageID::Nl},
-            {WinLanguageID::EnAU, LanguageID::En},       {WinLanguageID::EnBZ, LanguageID::En},
-            {WinLanguageID::EnCA, LanguageID::En},       {WinLanguageID::En029, LanguageID::En},
-            {WinLanguageID::EnIN, LanguageID::En},       {WinLanguageID::EnIE, LanguageID::En},
-            {WinLanguageID::EnJM, LanguageID::En},       {WinLanguageID::EnMY, LanguageID::En},
-            {WinLanguageID::EnNZ, LanguageID::En},       {WinLanguageID::EnPH, LanguageID::En},
-            {WinLanguageID::EnSG, LanguageID::En},       {WinLanguageID::EnZA, LanguageID::En},
-            {WinLanguageID::EnTT, LanguageID::En},       {WinLanguageID::EnGB, LanguageID::En},
-            {WinLanguageID::En, LanguageID::En},         {WinLanguageID::EnZW, LanguageID::En},
-            {WinLanguageID::Et, LanguageID::En},         {WinLanguageID::Fo, LanguageID::Fo},
-            {WinLanguageID::Fil, LanguageID::Unknown},   {WinLanguageID::Fi, LanguageID::Fi},
-            {WinLanguageID::FrBE, LanguageID::Fr},       {WinLanguageID::FrCA, LanguageID::Fr},
-            {WinLanguageID::Fr, LanguageID::Fr},         {WinLanguageID::FrLU, LanguageID::Fr},
-            {WinLanguageID::FrMC, LanguageID::Fr},       {WinLanguageID::FrCH, LanguageID::Fr},
-            {WinLanguageID::Fy, LanguageID::Unknown},    {WinLanguageID::Gl, LanguageID::Gl},
-            {WinLanguageID::Ka, LanguageID::Ka},         {WinLanguageID::DeAT, LanguageID::De},
-            {WinLanguageID::De, LanguageID::De},         {WinLanguageID::DeLI, LanguageID::De},
-            {WinLanguageID::DeLU, LanguageID::De},       {WinLanguageID::DeCH, LanguageID::De},
-            {WinLanguageID::El, LanguageID::El},         {WinLanguageID::Kl, LanguageID::Kl},
-            {WinLanguageID::Gu, LanguageID::Gu},         {WinLanguageID::Ha, LanguageID::En},
-            {WinLanguageID::He, LanguageID::He},         {WinLanguageID::Hi, LanguageID::Hi},
-            {WinLanguageID::Hu, LanguageID::Hu},         {WinLanguageID::Is, LanguageID::Is},
-            {WinLanguageID::Ig, LanguageID::Unknown},    {WinLanguageID::Id, LanguageID::Id},
-            {WinLanguageID::Iu, LanguageID::Iu},         {WinLanguageID::IuLatn, LanguageID::En},
-            {WinLanguageID::Ga, LanguageID::Ga},         {WinLanguageID::Xh, LanguageID::Unknown},
-            {WinLanguageID::Zu, LanguageID::Unknown},    {WinLanguageID::It, LanguageID::It},
-            {WinLanguageID::ItCH, LanguageID::It},       {WinLanguageID::Ja, LanguageID::Ja},
-            {WinLanguageID::Kn, LanguageID::Kn},         {WinLanguageID::Kk, LanguageID::Kk},
-            {WinLanguageID::Km, LanguageID::Km},         {WinLanguageID::Quc, LanguageID::Unknown},
-            {WinLanguageID::Rw, LanguageID::Rw},         {WinLanguageID::Sw, LanguageID::Sw},
-            {WinLanguageID::Kok, LanguageID::Unknown},   {WinLanguageID::Ko, LanguageID::Ko},
-            {WinLanguageID::Ky, LanguageID::Ky},         {WinLanguageID::Lo, LanguageID::Lo},
-            {WinLanguageID::Lv, LanguageID::Lv},         {WinLanguageID::Lt, LanguageID::Lt},
-            {WinLanguageID::Dsb, LanguageID::Unknown},   {WinLanguageID::Lb, LanguageID::Unknown},
-            {WinLanguageID::Mk, LanguageID::Mk},         {WinLanguageID::MsBN, LanguageID::Ms},
-            {WinLanguageID::Ms, LanguageID::Ms},         {WinLanguageID::Ml, LanguageID::Ml},
-            {WinLanguageID::Mt, LanguageID::Mt},         {WinLanguageID::Mi, LanguageID::Unknown},
-            {WinLanguageID::Arn, LanguageID::Unknown},   {WinLanguageID::Mr, LanguageID::Mr},
-            {WinLanguageID::Moh, LanguageID::Unknown},   {WinLanguageID::Mn, LanguageID::Mn},
-            {WinLanguageID::MnCN, LanguageID::MnCN},     {WinLanguageID::Ne, LanguageID::Ne},
-            {WinLanguageID::Nb, LanguageID::Unknown},    {WinLanguageID::Nn, LanguageID::Nn},
-            {WinLanguageID::Oc, LanguageID::Fr},         {WinLanguageID::Or, LanguageID::Or},
-            {WinLanguageID::Ps, LanguageID::Ps},         {WinLanguageID::Pl, LanguageID::Pl},
-            {WinLanguageID::Pt, LanguageID::Pt},         {WinLanguageID::PtPT, LanguageID::Pt},
-            {WinLanguageID::Pa, LanguageID::Pa},         {WinLanguageID::QuBO, LanguageID::Qu},
-            {WinLanguageID::QuEC, LanguageID::Qu},       {WinLanguageID::Qu, LanguageID::Qu},
-            {WinLanguageID::Ro, LanguageID::Ro},         {WinLanguageID::Rm, LanguageID::Unknown},
-            {WinLanguageID::Ru, LanguageID::Ru},         {WinLanguageID::Smn, LanguageID::Unknown},
-            {WinLanguageID::SmjNO, LanguageID::Unknown}, {WinLanguageID::Smj, LanguageID::Unknown},
-            {WinLanguageID::SeFI, LanguageID::Se},       {WinLanguageID::Se, LanguageID::Se},
-            {WinLanguageID::SeSE, LanguageID::Se},       {WinLanguageID::Sms, LanguageID::Unknown},
-            {WinLanguageID::SmaNO, LanguageID::Unknown}, {WinLanguageID::Sms1, LanguageID::Unknown},
-            {WinLanguageID::Sa, LanguageID::Sa},         {WinLanguageID::SrCyrlBA, LanguageID::Ru},
-            {WinLanguageID::Sr, LanguageID::Sr},         {WinLanguageID::SrLatnBA, LanguageID::En},
-            {WinLanguageID::SrLatn, LanguageID::En},     {WinLanguageID::Nso, LanguageID::Unknown},
-            {WinLanguageID::Tn, LanguageID::Unknown},    {WinLanguageID::Si, LanguageID::Si},
-            {WinLanguageID::Sk, LanguageID::Sk},         {WinLanguageID::Sl, LanguageID::Pl},
-            {WinLanguageID::EsAR, LanguageID::Es},       {WinLanguageID::EsBO, LanguageID::Es},
-            {WinLanguageID::EsCL, LanguageID::Es},       {WinLanguageID::EsCO, LanguageID::Es},
-            {WinLanguageID::EsCR, LanguageID::Es},       {WinLanguageID::EsDO, LanguageID::Es},
-            {WinLanguageID::EsEC, LanguageID::Es},       {WinLanguageID::EsSV, LanguageID::Es},
-            {WinLanguageID::EsGT, LanguageID::Es},       {WinLanguageID::EsHN, LanguageID::Es},
-            {WinLanguageID::EsMX, LanguageID::Es},       {WinLanguageID::EsNI, LanguageID::Es},
-            {WinLanguageID::EsPA, LanguageID::Es},       {WinLanguageID::EsPY, LanguageID::Es},
-            {WinLanguageID::EsPE, LanguageID::Es},       {WinLanguageID::EsPR, LanguageID::Es},
-            {WinLanguageID::Es, LanguageID::Es},         {WinLanguageID::Es1, LanguageID::Es},
-            {WinLanguageID::EsUS, LanguageID::Es},       {WinLanguageID::EsUY, LanguageID::Es},
-            {WinLanguageID::EsVE, LanguageID::Es},       {WinLanguageID::SvFI, LanguageID::Sv},
-            {WinLanguageID::Sv, LanguageID::Sv},         {WinLanguageID::Syr, LanguageID::Unknown},
-            {WinLanguageID::Tg, LanguageID::Tg},         {WinLanguageID::Tzm, LanguageID::Unknown},
-            {WinLanguageID::Ta, LanguageID::Ta},         {WinLanguageID::Tt, LanguageID::Tt},
-            {WinLanguageID::Te, LanguageID::Te},         {WinLanguageID::Th, LanguageID::Th},
-            {WinLanguageID::Bo, LanguageID::Bo},         {WinLanguageID::Tr, LanguageID::Tr},
-            {WinLanguageID::Tk, LanguageID::Tk},         {WinLanguageID::Ug, LanguageID::Ug},
-            {WinLanguageID::Uk, LanguageID::Uk},         {WinLanguageID::Hsb, LanguageID::Unknown},
-            {WinLanguageID::Ur, LanguageID::Ur},         {WinLanguageID::UzCyrl, LanguageID::Uz},
-            {WinLanguageID::Uz, LanguageID::Uz},         {WinLanguageID::Vi, LanguageID::Vi},
-            {WinLanguageID::Cy, LanguageID::Cy},         {WinLanguageID::Wo, LanguageID::Unknown},
-            {WinLanguageID::Sah, LanguageID::Unknown},   {WinLanguageID::Ii, LanguageID::Unknown},
-            {WinLanguageID::Yo, LanguageID::Unknown},
-        };
-        enum class PlatformID { Unicode, Macintosh, Windows = 3 };
-
-        struct Record {
-            LanguageID language;
-            std::string data;
-        };
-
-        std::map<RecordType, Record> records;
+    class PostTable {
+        static constexpr uint32_t Tag = 1886352244;
+        FontTableParser parser;
 
       public:
-        NameTable(HbFontT *font) {
-            FontTableParser parser{font, Tag};
-            uint16_t version = parser.getNext();
-            uint16_t nRecords = parser.getNext();
-            auto *tableOffset = parser.startPtr + parser.getNext();
-            for (size_t i = 0; i < nRecords; i++) {
-                auto platformId = static_cast<PlatformID>(parser.getNext());
-                auto encodingId = parser.getNext();
-                auto languageId = parser.getNext();
-                auto nameId = static_cast<RecordType>(parser.getNext());
-                auto stringLength = parser.getNext();
-                auto stringOffset = parser.getNext();
-                if (nameId > RecordType::VariationsPostScriptNamePrefix) // Not a standard name
-                    continue;
+        uint32_t version{parser.getNext<uint32_t>()};
+        int32_t italicAngle{parser.getNext<int32_t>()};
+        int16_t underlinePosition{parser.getNext<int16_t>()};
+        int16_t underlineThickness{parser.getNext<int16_t>()};
+        uint32_t isFixedPitch{parser.getNext<uint32_t>()};
+        // We don't care about the rest
+        PostTable(HbFontT *font) : parser{font, Tag} {};
 
-                LanguageID language;
-                switch (platformId) {
-                    case PlatformID::Macintosh:
-                        if (languageId <= static_cast<uint16_t>(MacLanguageID::Eo))
-                            language = static_cast<LanguageID>(languageId);
-                        else
-                            language = static_cast<LanguageID>(languageId + static_cast<uint16_t>(MacLanguageID::Eo) -
-                                                               static_cast<uint16_t>(MacLanguageID::Cy) - 1);
-                        break;
-                    case PlatformID::Windows:
-                        language = WinMap.contains(static_cast<WinLanguageID>(languageId))
-                                       ? WinMap.at(static_cast<WinLanguageID>(languageId))
-                                       : LanguageID::Unknown;
-                        break;
-                    case PlatformID::Unicode:
-                        language = LanguageID::En;
-                        break;
-                };
-                if ((!records.contains(nameId)) ||
-                    (language == LanguageID::En && records.at(nameId).language != LanguageID::En)) {
-                    auto &ref = records[nameId];
-                    ref.language = language;
-                    switch (platformId) {
-                        case PlatformID::Unicode:
-                        case PlatformID::Windows:
-                            ref.data = QUtil::utf16_to_utf8(std::string((tableOffset + stringOffset), stringLength));
-                            break;
-                        case PlatformID::Macintosh:
-                            ref.data = ref.data =
-                                QUtil::mac_roman_to_utf8(std::string((tableOffset + stringOffset), stringLength));
-                            break;
-                    }
-                }
-            }
-        };
-
-        bool contains(RecordType type) const {
-            return records.contains(type);
-        }
-
-        const std::string operator[](RecordType type) const {
-            return records.at(type).data;
-        };
-
-        const Record get(RecordType type) const {
-            return records.at(type);
-        }
-
-    } nameTable;
+    } postTable;
 
   public:
     const double scale;
@@ -770,28 +137,51 @@ class Font {
     }
 
     std::string getFamily() {
-        if (nameTable.contains(NameTable::RecordType::TypographicFamily))
-            return nameTable[NameTable::RecordType::TypographicFamily];
-        else
-            return nameTable[NameTable::RecordType::Family];
+        std::string out;
+        out.resize(50);
+        unsigned int length = 50;
+        if (hb_ot_name_get_utf8(font, HB_OT_NAME_ID_TYPOGRAPHIC_FAMILY, HB_LANGUAGE_INVALID, &length, &out[0]) == 0) {
+            length = 50;
+            hb_ot_name_get_utf8(font, HB_OT_NAME_ID_FONT_FAMILY, HB_LANGUAGE_INVALID, &length, &out[0]);
+        }
+
+        out.resize(length);
+        return out;
     }
 
     std::string getName() {
-        if (nameTable.contains(NameTable::RecordType::CompatibleFull))
-            return nameTable[NameTable::RecordType::CompatibleFull];
-        else
-            return nameTable[NameTable::RecordType::FullName];
+        std::string out;
+        out.resize(50);
+        unsigned int length = 50;
+        if (hb_ot_name_get_utf8(font, HB_OT_NAME_ID_MAC_FULL_NAME, HB_LANGUAGE_INVALID, &length, &out[0]) == 0) {
+            length = 50;
+            hb_ot_name_get_utf8(font, HB_OT_NAME_ID_FULL_NAME, HB_LANGUAGE_INVALID, &length, &out[0]);
+        }
+
+        out.resize(length);
+        return out;
     }
 
     std::string getSubFamily() {
-        if (nameTable.contains(NameTable::RecordType::TypographicSubFamily))
-            return nameTable[NameTable::RecordType::TypographicSubFamily];
-        else
-            return nameTable[NameTable::RecordType::SubFamily];
+        std::string out;
+        out.resize(50);
+        unsigned int length = 50;
+        if (hb_ot_name_get_utf8(font, HB_OT_NAME_ID_TYPOGRAPHIC_SUBFAMILY, HB_LANGUAGE_INVALID, &length, &out[0]) ==
+            0) {
+            length = 50;
+            hb_ot_name_get_utf8(font, HB_OT_NAME_ID_FONT_SUBFAMILY, HB_LANGUAGE_INVALID, &length, &out[0]);
+        }
+        out.resize(length);
+        return out;
     }
 
     std::string getPostScriptName() {
-        return nameTable[NameTable::RecordType::PostScriptName];
+        std::string out;
+        out.resize(50);
+        unsigned int length = 50;
+        hb_ot_name_get_utf8(font, HB_OT_NAME_ID_POSTSCRIPT_NAME, HB_LANGUAGE_INVALID, &length, &out[0]);
+        out.resize(length);
+        return out;
     }
 
     BBox getBoundingBox() {
@@ -802,6 +192,21 @@ class Font {
 
     int getVariations() {
         return hb_ot_var_get_axis_count(font);
+    }
+
+    uint8_t getFlags() {
+        uint8_t flags = 0;
+        uint8_t familyClass = (os2Table.sFamilyClass) >> 8;
+        if (postTable.isFixedPitch)
+            flags |= 1;
+        if (familyClass > 0 && familyClass < 8)
+            flags |= 1 << 1;
+        else if (familyClass == 10)
+            flags |= 1 << 3;
+        flags |= 1 << 2;
+        if (headTable.macStyle & 2)
+            flags |= 1 << 6;
+        return flags;
     }
 
     std::function<void(Pipeline *)> makeSubsetFunction(Face &face, QPDFObjectHandle dict);

--- a/include/fontManager.hpp
+++ b/include/fontManager.hpp
@@ -46,8 +46,9 @@ class FontManager {
         return dictionary;
     }
 
-    std::vector<std::string> loadFontFile(std::filesystem::path file);
-    void embedFonts();
+    std::vector<std::string> loadFontFile(std::filesystem::path file, uint32_t startIndex = 0,
+                                          std::optional<uint32_t> maxFonts = std::nullopt);
+    void embedFonts(bool subset = true);
 };
 }; // namespace PDFLib
 #endif

--- a/include/pdf.hpp
+++ b/include/pdf.hpp
@@ -29,12 +29,11 @@ class Document {
         Page(Document &doc) : doc{doc}, pageDict{doc.newIndirectObject(QPDFObjectHandle::newDictionary())} {
             pageDict.replaceKey("/Type", QPDFObjectHandle::newName("/Page"));
             pageDict.replaceKey("/MediaBox", QPDFObjectHandle::newArray(QPDFObjectHandle::Rectangle(0, 0, 600, 850)));
-            pageDict.replaceKey("/CropBox",
-                                QPDFObjectHandle::newArray(QPDFObjectHandle::Rectangle(2.5, 3.5, 595, 842)));
+            pageDict.replaceKey("/CropBox", QPDFObjectHandle::newArray(QPDFObjectHandle::Rectangle(2.5, 4, 595, 842)));
             pageDict.replaceKey("/Resources", doc.resources);
             doc.pages.addPage(pageDict, false);
         }
-        void setContents(std::string &contents) {
+        void setContents(const std::string &contents) {
             pageDict.replaceKey("/Contents", QPDFObjectHandle::newStream(&doc.pdf, contents));
         }
     };
@@ -42,13 +41,17 @@ class Document {
   public:
     Document() : pages{(pdf.emptyPDF(), pdf)}, resources{QPDFObjectHandle::newDictionary()}, fontManager{*this} {};
 
-    void write(std::filesystem::path path) {
-        QPDFWriter w(pdf, path.c_str());
+    void finish() {
         fontManager.embedFonts();
         resources.replaceKey("/Font", fontManager.getDictionary());
+    }
+
+    void write(std::filesystem::path path) {
+        QPDFWriter w(pdf, path.c_str());
         w.setCompressStreams(true);
         w.setPreserveUnreferencedObjects(true);
         w.setLinearization(true);
+        w.setMinimumPDFVersion(PDFVersion(1, 6));
         w.write();
     }
 

--- a/include/pdf.hpp
+++ b/include/pdf.hpp
@@ -42,15 +42,15 @@ class Document {
     Document() : pages{(pdf.emptyPDF(), pdf)}, resources{QPDFObjectHandle::newDictionary()}, fontManager{*this} {};
 
     void finish() {
-        fontManager.embedFonts();
+        fontManager.embedFonts(true);
         resources.replaceKey("/Font", fontManager.getDictionary());
     }
 
     void write(std::filesystem::path path) {
         QPDFWriter w(pdf, path.c_str());
-        w.setCompressStreams(true);
-        w.setPreserveUnreferencedObjects(true);
-        w.setLinearization(true);
+        w.setCompressStreams(false);
+        w.setPreserveUnreferencedObjects(false);
+        w.setLinearization(false);
         w.setMinimumPDFVersion(PDFVersion(1, 6));
         w.write();
     }

--- a/include/private/font-tables/parser.hpp
+++ b/include/private/font-tables/parser.hpp
@@ -5,34 +5,57 @@
     #include <stddef.h>
     #include <stdint.h>
 
+    #include <span>
+
 namespace PDFLib {
 // A stateful helper class
-class FontTableParser {
+template <typename T> struct BasicParser {
     size_t offset = 0;
+    template <typename Type = uint16_t> Type getNext() {
+        Type out = *(static_cast<const T *>(this)->startPtr + offset++);
+        if constexpr (sizeof(Type) > 1)
+            for (size_t i = 1; i < sizeof(Type); i++) {
+                out <<= 8;
+                out |= *(static_cast<const T *>(this)->startPtr + offset++);
+            }
+        return out;
+    }
+
+    size_t getNext(size_t size) {
+        size_t out = *(static_cast<const T *>(this)->startPtr + offset++);
+        for (size_t i = 1; i < size; i++) {
+            out <<= 8;
+            out |= *(static_cast<const T *>(this)->startPtr + offset++);
+        }
+        return out;
+    }
+    template <typename Type = uint8_t> std::span<const Type> getBytes(size_t count) {
+        std::span<const Type> out{reinterpret_cast<const Type *>(static_cast<const T *>(this)->startPtr + offset),
+                                  count};
+        offset += count;
+        return out;
+    }
+
+    void moveTo(size_t pos) {
+        offset = pos;
+    }
+};
+
+class Parser : public BasicParser<Parser> {
+  public:
+    const uint8_t *startPtr;
+    Parser(const uint8_t *ptr) : startPtr{ptr} {};
+};
+
+class FontTableParser : public BasicParser<FontTableParser> {
     PtrHolder<HbBlobT, hb_blob_destroy, hb_face_reference_table> tableBlob;
-    const char *getTableRef() {
+    const uint8_t *getTableRef() {
         uint32_t _;
-        return hb_blob_get_data(tableBlob, &_);
+        return reinterpret_cast<const uint8_t *>(hb_blob_get_data(tableBlob, &_));
     };
 
   public:
-    const char *startPtr;
-
-    template <typename T = uint16_t> T getNext() {
-        const T u = *reinterpret_cast<const T *>(startPtr + offset);
-        offset += sizeof(T);
-
-        union {
-            T u;
-            unsigned char u8[sizeof(T)];
-        } source, dest;
-
-        source.u = u;
-        for (size_t k = 0; k < sizeof(T); k++)
-            dest.u8[k] = source.u8[sizeof(T) - k - 1];
-        return dest.u;
-    }
-
+    const uint8_t *startPtr;
     FontTableParser(HbFontT *ptr, uint32_t tag) : tableBlob{ptr, tag}, startPtr{getTableRef()} {};
 };
 } // namespace PDFLib

--- a/include/private/harfbuzz-helpers.hpp
+++ b/include/private/harfbuzz-helpers.hpp
@@ -4,12 +4,8 @@
 #include <hb.h>
 
 #include <filesystem>
+#include <iostream>
 #include <memory>
-namespace detail {
-inline constexpr auto _bufferDeleter = [](std::filesystem::path fontFile) -> auto{
-    return hb_blob_create_from_file(fontFile.c_str());
-};
-} // namespace detail
 namespace PDFLib {
 using HbFontT = hb_face_t;
 using HbFaceT = hb_font_t;
@@ -20,7 +16,20 @@ using HbSubsetInputT = hb_subset_input_t;
 struct nullarg_t { };
 inline constexpr nullarg_t nullarg;
 template <auto arg> inline constexpr bool is_nullarg_v = std::is_same_v<std::remove_cv_t<decltype(arg)>, nullarg_t>;
-
+struct HarfbuzzError : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+} // namespace PDFLib
+namespace detail {
+using ::PDFLib::HarfbuzzError;
+inline constexpr auto bufferInit = [](std::filesystem::path fontFile) -> auto{
+    if (auto blob = hb_blob_create_from_file_or_fail(fontFile.c_str()); blob != NULL) {
+        return blob;
+    }
+    throw HarfbuzzError(std::string("Failed to load font file: ") + fontFile.stem().c_str());
+};
+} // namespace detail
+namespace PDFLib {
 template <typename T, auto deleter = nullarg, auto initialiser = nullarg> class PtrHolder {
     struct PtrDeleter {
         void operator()(T *ptr) {
@@ -47,11 +56,12 @@ template <typename T, auto deleter = nullarg, auto initialiser = nullarg> class 
 
 using FaceHolder = PtrHolder<HbFaceT, hb_font_destroy>;
 using FontHolder = PtrHolder<HbFontT, hb_face_destroy>;
-using BlobHolder = PtrHolder<HbBlobT, hb_blob_destroy, detail::_bufferDeleter>;
+using BlobHolder = PtrHolder<HbBlobT, hb_blob_destroy, detail::bufferInit>;
 using BufferHolder = PtrHolder<HbBufferT, hb_buffer_destroy, hb_buffer_create>;
 
 using GlyphSetHolder = PtrHolder<HbSetT, nullarg, hb_subset_input_glyph_set>;
 using UnicodeSetHolder = PtrHolder<HbSetT, nullarg, hb_subset_input_unicode_set>;
+using SubsetSetHolder = PtrHolder<HbSetT, nullarg, hb_subset_input_set>;
 
 using SetHolder = PtrHolder<HbSetT, hb_set_destroy, hb_set_create>;
 

--- a/include/private/util.hpp
+++ b/include/private/util.hpp
@@ -4,26 +4,20 @@
 
 namespace PDFLib {
 namespace Util {
-template <typename T, auto deleter, auto initialiser = nullptr, bool owning = true> class PtrHolder {
-    using SafeT = std::unique_ptr<T, decltype([](T *ptr) {
-                                      if constexpr (owning)
-                                          deleter(ptr);
-                                  })>;
-    SafeT object;
-
-  public:
-    // Basically a std::make_unique for C functions
-    // Enable if initialiser is set
-    template <auto W = initialiser,
-              typename std::enable_if<!std::is_same_v<decltype(W), std::nullptr_t>, int>::type = 0>
-    PtrHolder(auto &&...args) : object{initialiser(std::forward<decltype(args)>(args)...)} {};
-
-    PtrHolder(T *object) : object{object} {};
-
-    operator T *() {
-        return object.get();
+template <size_t N> struct StringLiteral {
+    constexpr StringLiteral(const char (&str)[N]) {
+        std::copy_n(str, N, value);
     }
+    constexpr char operator[](size_t i) const {
+        return value[i];
+    }
+    char value[N];
+    size_t size = N;
 };
+
+template <StringLiteral c>
+constexpr unsigned int tag = (static_cast<unsigned int>(c[0]) << 24) | (static_cast<unsigned int>(c[1]) << 16) |
+                             (static_cast<unsigned int>(c[2]) << 8) | c[3];
 } // namespace Util
 } // namespace PDFLib
 

--- a/src/face.cpp
+++ b/src/face.cpp
@@ -5,14 +5,17 @@
 #include "fontManager.hpp"
 #include "pdf.hpp"
 
+#include <qpdf/QUtil.hh>
+
 #include <iostream>
 using namespace PDFLib;
 Face::Face(FaceHolder face, double scale, std::string handle)
     : glyphSet{subsetInput},
+      charSet{},
       face{std::move(face)},
       scale{scale},
       handle{handle} {
-    hb_subset_input_set_flags(subsetInput, HB_SUBSET_FLAGS_GLYPH_NAMES);
+    hb_subset_input_set_flags(subsetInput, HB_SUBSET_FLAGS_RETAIN_GIDS);
 };
 
 double Face::getAscender() {
@@ -26,6 +29,11 @@ double Face::getDescender() {
     hb_font_get_h_extents(face, &extents);
     return static_cast<double>(extents.descender) * scale;
 }
+double Face::getLineGap() {
+    hb_font_extents_t extents;
+    hb_font_get_h_extents(face, &extents);
+    return static_cast<double>(extents.line_gap) * scale;
+}
 
 float Face::getItalicAngle() {
     return hb_style_get_value(face, HB_STYLE_TAG_SLANT_ANGLE);
@@ -37,36 +45,49 @@ int Face::getCapHeight() {
     return out * scale;
 }
 
-std::pair<float, std::string> Face::shape(std::string text, float points) {
+std::pair<float, std::string> Face::shape(std::string_view text, float points, hb_script_t script,
+                                          hb_direction_t direction, std::string_view language) {
     BufferHolder buffer;
-    hb_buffer_add_utf8(buffer, text.c_str(), -1, 0, -1);
-    hb_buffer_set_direction(buffer, HB_DIRECTION_LTR);
-    hb_buffer_set_script(buffer, HB_SCRIPT_LATIN);
-    hb_buffer_set_language(buffer, hb_language_from_string("en", -1));
+    hb_buffer_add_utf8(buffer, text.begin(), -1, 0, -1);
+    hb_buffer_set_direction(buffer, direction);
+    hb_buffer_set_script(buffer, script);
+    hb_buffer_set_language(buffer, hb_language_from_string(language.begin(), -1));
     hb_shape(face, buffer, NULL, 0);
+
+    auto toHex = [](uint32_t w, size_t hex_len = 4) -> std::string {
+        static const char *digits = "0123456789ABCDEF";
+        std::string rc(hex_len, '0');
+        for (size_t i = 0, j = (hex_len - 1) * 4; i < hex_len; ++i, j -= 4)
+            rc[i] = digits[(w >> j) & 0x0f];
+        return rc;
+    };
 
     unsigned int glyph_count;
     hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(buffer, &glyph_count);
+    for (unsigned int i = 0; i < glyph_count; i++) {
+        if (glyph_info[i].codepoint == 0)
+            throw std::runtime_error("Required glyph not defined");
+    }
     hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(buffer, &glyph_count);
     float width = 0;
     float height = getAscender() - getDescender();
     std::string out;
-    out.reserve(text.length() * 2);
+    out.reserve(text.length() * 3);
     out.push_back('[');
-    out.push_back('(');
+    out.push_back('<');
     for (unsigned int i = 0; i < glyph_count; i++) {
         hb_codepoint_t glyphid = glyph_info[i].codepoint;
         hb_position_t x_advance = glyph_pos[i].x_advance;
         hb_position_t error = hb_font_get_glyph_h_advance(face, glyphid) - x_advance;
-        hb_set_add(glyphSet, text[i]);
+        hb_set_add(glyphSet, glyphid);
         width += x_advance;
-        out.push_back(text[i]);
+        out += toHex(glyphid);
         if (error) {
-            out.push_back(')');
+            out.push_back('>');
             out += std::to_string((int32_t)(error * scale));
-            out.push_back('(');
+            out.push_back('<');
         }
     }
-    out += ")]";
-    return std::make_tuple(width * scale * points / 1000.0, out);
+    out += ">]";
+    return std::make_pair(width * scale * points / 1000.0, out);
 };

--- a/src/face.cpp
+++ b/src/face.cpp
@@ -2,7 +2,6 @@
 #include "face.hpp"
 
 #include "font.hpp"
-#include "fontManager.hpp"
 #include "pdf.hpp"
 
 #include <qpdf/QUtil.hh>
@@ -14,9 +13,7 @@ Face::Face(FaceHolder face, double scale, std::string handle)
       charSet{},
       face{std::move(face)},
       scale{scale},
-      handle{handle} {
-    hb_subset_input_set_flags(subsetInput, HB_SUBSET_FLAGS_RETAIN_GIDS);
-};
+      handle{handle} {};
 
 double Face::getAscender() {
     hb_font_extents_t extents;
@@ -42,25 +39,19 @@ float Face::getItalicAngle() {
 int Face::getCapHeight() {
     int32_t out;
     hb_ot_metrics_get_position(face, HB_OT_METRICS_TAG_CAP_HEIGHT, &out);
-    return out * scale;
+    return (out * scale > 1 ? out * scale : getAscender());
 }
 
-std::pair<float, std::string> Face::shape(std::string_view text, float points, hb_script_t script,
-                                          hb_direction_t direction, std::string_view language) {
+std::pair<float, std::vector<std::pair<std::vector<uint32_t>, int32_t>>> Face::shape(std::string_view text,
+                                                                                     float points, hb_script_t script,
+                                                                                     hb_direction_t direction,
+                                                                                     std::string_view language) {
     BufferHolder buffer;
     hb_buffer_add_utf8(buffer, text.begin(), -1, 0, -1);
     hb_buffer_set_direction(buffer, direction);
     hb_buffer_set_script(buffer, script);
     hb_buffer_set_language(buffer, hb_language_from_string(language.begin(), -1));
     hb_shape(face, buffer, NULL, 0);
-
-    auto toHex = [](uint32_t w, size_t hex_len = 4) -> std::string {
-        static const char *digits = "0123456789ABCDEF";
-        std::string rc(hex_len, '0');
-        for (size_t i = 0, j = (hex_len - 1) * 4; i < hex_len; ++i, j -= 4)
-            rc[i] = digits[(w >> j) & 0x0f];
-        return rc;
-    };
 
     unsigned int glyph_count;
     hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(buffer, &glyph_count);
@@ -71,23 +62,19 @@ std::pair<float, std::string> Face::shape(std::string_view text, float points, h
     hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(buffer, &glyph_count);
     float width = 0;
     float height = getAscender() - getDescender();
-    std::string out;
-    out.reserve(text.length() * 3);
-    out.push_back('[');
-    out.push_back('<');
+    std::vector<std::pair<std::vector<uint32_t>, int32_t>> runs;
+    runs.emplace_back();
     for (unsigned int i = 0; i < glyph_count; i++) {
         hb_codepoint_t glyphid = glyph_info[i].codepoint;
         hb_position_t x_advance = glyph_pos[i].x_advance;
         hb_position_t error = hb_font_get_glyph_h_advance(face, glyphid) - x_advance;
         hb_set_add(glyphSet, glyphid);
         width += x_advance;
-        out += toHex(glyphid);
+        runs.back().first.push_back(glyphid);
         if (error) {
-            out.push_back('>');
-            out += std::to_string((int32_t)(error * scale));
-            out.push_back('<');
+            runs.back().second = ((int32_t)(error * scale));
+            runs.emplace_back();
         }
     }
-    out += ">]";
-    return std::make_pair(width * scale * points / 1000.0, out);
+    return std::make_pair(width * scale * points / 1000.0, runs);
 };

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -11,9 +11,9 @@ PDFLib::Font::Font(HbFontT *fontHandle, FontManager &manager, size_t index)
       blob{hb_face_reference_blob(font)},
       manager{manager},
       headTable{font},
-      nameTable{font},
       index{index},
       os2Table{font},
+      postTable{font},
       scale{1000.0 / static_cast<double>(headTable.unitsPerEM)} {};
 
 PDFLib::Face &PDFLib::Font::makeFace() {

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -4,30 +4,49 @@
 #include "fontManager.hpp"
 #include "pdf.hpp"
 
-#include <qpdf/Pipeline.hh>
+#include <fstream>
 
-PDFLib::Font::Font(HbFontT *fontHandle, FontManager &manager, size_t index)
+PDFLib::Font::Font(HbFontT *fontHandle, size_t index)
     : font{fontHandle},
       blob{hb_face_reference_blob(font)},
-      manager{manager},
       headTable{font},
       index{index},
       os2Table{font},
       postTable{font},
-      scale{1000.0 / static_cast<double>(headTable.unitsPerEM)} {};
+      scale{1000.0 / static_cast<double>(headTable.unitsPerEM)} {
+    {
+        std::array<uint32_t, 10> tags;
+        uint32_t length = 10;
+        uint32_t total = 0;
+        while (length > 0) {
+            hb_face_get_table_tags(font, total, &length, tags.data());
+            total += length;
+            if (length > 0)
+                for (auto tag : tags) {
+                    if (tag == Util::tag<"CFF ">)
+                        CFF = true;
+                }
+        }
+    }
+    if (CFF)
+        cffTable.emplace(font);
+};
 
 PDFLib::Face &PDFLib::Font::makeFace() {
     return faces.emplace_back(
         hb_font_create(font), scale, "/F" + std::to_string(index) + "v" + std::to_string(faces.size()));
 }
-std::function<void(Pipeline *)> PDFLib::Font::makeSubsetFunction(Face &face, QPDFObjectHandle dict) {
-    return [&face, this, dict](Pipeline *pipeline) mutable {
-        FontHolder subsetFont = hb_subset_or_fail(font, face.getSubsetInput());
-        BlobHolder subsetBlob = hb_face_reference_blob(subsetFont);
-
+std::function<void(Pipeline *)> PDFLib::Font::makeSubsetFunction(Face &face, bool subset) {
+    return [&face, this, subset](Pipeline *pipeline) mutable {
         unsigned int length;
-        pipeline->write(hb_blob_get_data(subsetBlob, &length), length);
+        if (subset) {
+            hb_subset_input_set_flags(face.getSubsetInput(), HB_SUBSET_FLAGS_RETAIN_GIDS);
+            FontHolder subsetFont = hb_subset_or_fail(font, face.getSubsetInput());
+            BlobHolder subsetBlob = hb_face_reference_blob(subsetFont);
+            pipeline->write(hb_blob_get_data(subsetBlob, &length), length);
+        } else
+            pipeline->write(hb_blob_get_data(blob, &length), length);
+
         pipeline->finish();
-        dict.replaceKey("/Length1", QPDFObjectHandle::newInteger(length));
     };
 }

--- a/src/fontManager.cpp
+++ b/src/fontManager.cpp
@@ -2,54 +2,115 @@
 #include "fontManager.hpp"
 
 #include "pdf.hpp"
+
+#include <limits>
+#include <random>
 using namespace PDFLib;
 
 FontManager::FontManager(Document &document)
     : document{document},
       dictionary{document.newIndirectObject(QPDFObjectHandle::newDictionary())} {};
 
-void FontManager::embedFonts() {
+// We embed fonts at the end
+void FontManager::embedFonts(bool subset) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> distrib('A', 'Z');
+
     for (auto &&[key, font] : fonts) {
         auto &faces = font.getFaces();
         for (auto &&face : faces) {
+            if (hb_set_get_population(face.getUsedGlyphs()) == 0)
+                continue;
+
             auto fontDescriptor = document.newIndirectObject(QPDFObjectHandle::newDictionary());
             auto fontDictionary = document.newIndirectObject(QPDFObjectHandle::newDictionary());
             auto descendantFontDictionary = document.newIndirectObject(QPDFObjectHandle::newDictionary());
 
+            std::string name = (subset ? "/AAAAAA+" : "/") + font.getPostScriptName();
+            if (subset) {
+                for (size_t i = 1; i <= 6; ++i)
+                    name[i] = static_cast<char>(distrib(gen));
+                name += "Identity-H";
+            }
+
             fontDescriptor.replaceKey("/Type", QPDFObjectHandle::newName("/FontDescriptor"));
             fontDescriptor.replaceKey("/FontBBox", font.getBoundingBox());
-            fontDescriptor.replaceKey("/FontName",
-                                      QPDFObjectHandle::newName("/" + std::string(font.getPostScriptName())));
+            fontDescriptor.replaceKey("/FontName", QPDFObjectHandle::newName(name));
             fontDescriptor.replaceKey("/ItalicAngle", QPDFObjectHandle::newReal(face.getSlantAngle(), 1));
             fontDescriptor.replaceKey("/Ascent", QPDFObjectHandle::newInteger(face.getAscender()));
             fontDescriptor.replaceKey("/Flags", QPDFObjectHandle::newInteger(font.getFlags()));
             fontDescriptor.replaceKey("/Descent", QPDFObjectHandle::newInteger(face.getDescender()));
-            fontDescriptor.replaceKey("/CapHeight",
-                                      QPDFObjectHandle::newInteger(face.getCapHeight() || face.getAscender()));
+            fontDescriptor.replaceKey("/CapHeight", QPDFObjectHandle::newInteger(face.getCapHeight()));
             fontDescriptor.replaceKey("/StemV", QPDFObjectHandle::newInteger(10 + (face.getWeight() - 50) * 220 / 900));
 
+            auto CIDSystemInfo = QPDFObjectHandle::newDictionary();
+            CIDSystemInfo.replaceKey("/Registry", QPDFObjectHandle::newString("Adobe"));
+            CIDSystemInfo.replaceKey("/Ordering", QPDFObjectHandle::newString("Identity"));
+            CIDSystemInfo.replaceKey("/Supplement", QPDFObjectHandle::newInteger(0));
+
             descendantFontDictionary.replaceKey("/Type", QPDFObjectHandle::newName("/Font"));
-            descendantFontDictionary.replaceKey("/Subtype", QPDFObjectHandle::newName("/CIDFontType2"));
-            descendantFontDictionary.replaceKey("/CIDToGIDMap", QPDFObjectHandle::newName("/Identity"));
-            descendantFontDictionary.replaceKey("/BaseFont",
-                                                QPDFObjectHandle::newName("/" + std::string(font.getPostScriptName())));
-            descendantFontDictionary.replaceKey("/CIDSystemInfo",
-                                                "<< /Registry (Adobe) /Ordering (Identity) /Supplement 0 >>"_qpdf);
-            descendantFontDictionary.replaceKey("/FontDescriptor", fontDescriptor);
-
-            std::vector<QPDFObjectHandle> glyphAdvances{};
-            for (size_t i = 0; i <= hb_set_get_max(face.getUsedGlyphs()); ++i)
-                glyphAdvances.push_back(QPDFObjectHandle::newInteger(face.getGlyphAdvance(i)));
-
             descendantFontDictionary.replaceKey(
-                "/W",
-                document.newIndirectObject(QPDFObjectHandle::newArray(
-                    {QPDFObjectHandle::newInteger(0), QPDFObjectHandle::newArray(glyphAdvances)})));
-
+                "/Subtype", QPDFObjectHandle::newName(font.isCFF() ? "/CIDFontType0" : "/CIDFontType2"));
+            if (!font.isCFF())
+                descendantFontDictionary.replaceKey("/CIDToGIDMap", QPDFObjectHandle::newName("/Identity"));
+            descendantFontDictionary.replaceKey("/BaseFont", QPDFObjectHandle::newName(name));
+            descendantFontDictionary.replaceKey("/CIDSystemInfo", CIDSystemInfo);
+            descendantFontDictionary.replaceKey("/FontDescriptor", fontDescriptor);
+            {
+                auto &glyphs = face.getUsedGlyphs();
+                size_t max = (subset ? hb_set_get_max(glyphs) : hb_face_get_glyph_count(font.getHbObj()));
+                size_t min = (subset ? hb_set_get_min(glyphs) : 0);
+                size_t pop = (subset ? hb_set_get_population(glyphs) : hb_face_get_glyph_count(font.getHbObj()));
+                // {
+                //     std::vector<uint32_t> vec;
+                //     vec.reserve(pop);
+                //     for (uint32_t i = HB_SET_VALUE_INVALID; hb_set_next(glyphs, &i);) {
+                //         uint32_t adv = face.getGlyphAdvance(i);
+                //         vec.insert(std::upper_bound(vec.begin(), vec.end(), i), i);
+                //     }
+                // }
+                {
+                    std::vector<QPDFObjectHandle> glyphAdvances{};
+                    if (subset)
+                        for (uint32_t i = HB_SET_VALUE_INVALID; hb_set_next(glyphs, &i);) {
+                            uint32_t adv = face.getGlyphAdvance(i);
+                            if (adv == 1000)
+                                continue;
+                            glyphAdvances.push_back(QPDFObjectHandle::newInteger(i));
+                            std::vector<QPDFObjectHandle> advances{};
+                            while (i <= max) {
+                                advances.push_back(QPDFObjectHandle::newInteger(adv));
+                                if (!hb_set_has(glyphs, ++i))
+                                    break;
+                                adv = face.getGlyphAdvance(i);
+                                if (adv == 1000)
+                                    break;
+                            }
+                            glyphAdvances.push_back(QPDFObjectHandle::newArray(advances));
+                        }
+                    else
+                        for (uint32_t i = min; i < max; i++) {
+                            uint32_t adv = face.getGlyphAdvance(i);
+                            if (adv == 1000)
+                                continue;
+                            glyphAdvances.push_back(QPDFObjectHandle::newInteger(i));
+                            std::vector<QPDFObjectHandle> advances{};
+                            while (i <= max) {
+                                advances.push_back(QPDFObjectHandle::newInteger(adv));
+                                adv = face.getGlyphAdvance(++i);
+                                if (adv == 1000)
+                                    break;
+                            }
+                            glyphAdvances.push_back(QPDFObjectHandle::newArray(advances));
+                        }
+                    descendantFontDictionary.replaceKey(
+                        "/W", document.newIndirectObject(QPDFObjectHandle::newArray(glyphAdvances)));
+                }
+            }
             fontDictionary.replaceKey("/Type", QPDFObjectHandle::newName("/Font"));
             fontDictionary.replaceKey("/Subtype", QPDFObjectHandle::newName("/Type0"));
-            fontDictionary.replaceKey("/BaseFont",
-                                      QPDFObjectHandle::newName("/" + std::string(font.getPostScriptName())));
+            fontDictionary.replaceKey("/BaseFont", QPDFObjectHandle::newName(name));
             fontDictionary.replaceKey("/Encoding", QPDFObjectHandle::newName("/Identity-H"));
 
             fontDictionary.replaceKey("/DescendantFonts", QPDFObjectHandle::newArray({descendantFontDictionary}));
@@ -57,21 +118,27 @@ void FontManager::embedFonts() {
             dictionary.replaceKey(face.getHandle(), fontDictionary);
             auto stream = document.newStream();
             auto dict = stream.getDict();
+            dict.replaceKey("/Subtype", QPDFObjectHandle::newName("/OpenType"));
+
             stream.replaceStreamData(
-                font.makeSubsetFunction(face, dict), QPDFObjectHandle(), QPDFObjectHandle::newNull());
-            fontDescriptor.replaceKey("/FontFile2", stream);
+                font.makeSubsetFunction(face, subset), QPDFObjectHandle(), QPDFObjectHandle::newNull());
+
+            fontDescriptor.replaceKey("/FontFile3", stream);
         }
     }
 }
 
 // TODO: Add support for vertical writing
-std::vector<std::string> FontManager::loadFontFile(std::filesystem::path file) {
+std::vector<std::string> FontManager::loadFontFile(std::filesystem::path file, uint32_t startIndex,
+                                                   std::optional<uint32_t> maxFonts) {
     BlobHolder blob{file};
     std::vector<std::string> out;
-    auto fontCount = hb_face_count(blob);
+    auto fontCount =
+        std::min(hb_face_count(blob), startIndex + maxFonts.value_or(std::numeric_limits<uint16_t>::max()));
+
     out.reserve(fontCount);
-    for (size_t i = 0; i < fontCount; ++i) {
-        auto font = Font(hb_face_create(blob, i), *this, fonts.size());
+    for (size_t i = startIndex; i < fontCount; ++i) {
+        Font font{hb_face_create(blob, i), fonts.size()};
         auto name = font.getName();
         fonts.emplace(std::make_pair(name, std::move(font)));
         out.emplace_back(name);


### PR DESCRIPTION
Changed font implementation to use CID fonts, allowing for non-latin scripts. Added examples of Han, Devanagari, Ethiopic, and Arabic scripts to the example document.

TODO:
 - add support for non-truetype CID fonts
 - add ToUnicode maps
 - add support for vertical writing
 - Improve implementation