### PR TITLE
Add support for CID fonts, including CID keyed CFF fonts

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+PDF-Generator

--- a/.idea/ModernPDF.iml
+++ b/.idea/ModernPDF.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <clangFormatSettings>
+      <option name="ENABLED" value="true" />
+    </clangFormatSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ModernPDF.iml" filepath="$PROJECT_DIR$/.idea/ModernPDF.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/examples/test.cpp
+++ b/examples/test.cpp
@@ -112,7 +112,15 @@ inline std::string latinTest(FontManager &fontManager, double points, double lin
 inline double CJKTest(FontManager &fontManager, std::string &contents) {
     int points = 15;
     double pos = 40;
+    bool ping = false;
     for (auto &&[name, font] : fontManager.getFonts()) {
+
+        if (name.find("Ping") != std::string::npos){
+            if(!ping)
+                ping = true;
+            else
+                continue;
+        }
         auto &face = font.getFaces()[0];
         const std::vector<std::string_view> lines{
             std::string_view("人皆生而自由；在尊嚴及權利上均各平等！人各賦有理性良知，誠應和睦相處，情"),
@@ -129,9 +137,8 @@ inline double CJKTest(FontManager &fontManager, std::string &contents) {
                 contents += Text((595.0 - width) / 2.0, 842 - pos, face, font.runToString(text), points);
                 pos += height;
             }
-            pos += 40;
-            break;
         } catch (std::runtime_error e) {
+            std::cout << "Missing glyphs from " << name << "\n";
             continue;
         }
     }
@@ -159,7 +166,6 @@ inline void ArabicTest(FontManager &fontManager, double &pos, std::string &conte
         } catch (std::runtime_error e) {
             continue;
         }
-        pos += 40;
     }
 }
 inline void DevanagariTest(FontManager &fontManager, double &pos, std::string &contents) {
@@ -186,7 +192,6 @@ inline void DevanagariTest(FontManager &fontManager, double &pos, std::string &c
         } catch (std::runtime_error e) {
             continue;
         }
-        pos += 40;
     }
 }
 inline void EthiopicTest(FontManager &fontManager, double &pos, std::string &contents) {
@@ -211,7 +216,6 @@ inline void EthiopicTest(FontManager &fontManager, double &pos, std::string &con
         } catch (std::runtime_error e) {
             continue;
         }
-        pos += 40;
     }
 }
 inline void EmojiTest(FontManager &fontManager, double &pos, std::string &contents) {
@@ -230,7 +234,6 @@ inline void EmojiTest(FontManager &fontManager, double &pos, std::string &conten
                 contents += Text((595.0 - width) / 2.0, 842 - pos, face, font.runToString(text), points);
                 pos += height;
             }
-            pos += 38;
         } catch (std::runtime_error e) {
             continue;
         }


### PR DESCRIPTION
Most non-BMP languages require CID fonts to correctly display most glyphs. In the case of CJK fonts these are often CFF fonts with CID keys. 

### What we want
Full support for CID font embedding, including CFF fonts. CFF fonts with missing SIDs should also work as expected.
